### PR TITLE
fixed issued: first message was not sent because connection was not yet opened

### DIFF
--- a/iot-hub/Quickstarts/simulated-device/SimulatedDevice.js
+++ b/iot-hub/Quickstarts/simulated-device/SimulatedDevice.js
@@ -25,6 +25,32 @@ var Message = require('azure-iot-device').Message;
 
 var client = DeviceClient.fromConnectionString(connectionString, Mqtt);
 
+client.open(function (err) {
+  if (err) {
+    console.log('Could not connect: ' + err.message);
+  } else {
+    console.log('Connected to IoT Hub!');
+    // Create a message and send it to the IoT hub every second
+    setInterval(function () {
+      // Simulate telemetry.
+      var temperature = 20 + (Math.random() * 15);
+      var humidity = 60 + (Math.random() * 20);
+
+      // Add the telemetry to the message body.
+      var data = JSON.stringify({ temperature: temperature, humidity: humidity });
+      var message = new Message(data);
+
+      // Add a custom application property to the message.
+      // An IoT hub can filter on these properties without access to the message body.
+      message.properties.add('temperatureAlert', (temperature > 30) ? 'true' : 'false');
+      console.log('Sending message: ' + message.getData());
+
+      // Send the message.
+      client.sendEvent(message, printResultFor('send'));
+    }, 1000);
+  }
+});
+
 // Print results.
 function printResultFor(op) {
   return function printResult(err, res) {
@@ -32,22 +58,3 @@ function printResultFor(op) {
     if (res) console.log(op + ' status: ' + res.constructor.name);
   };
 }
-
-// Create a message and send it to the IoT hub every second
-setInterval(function(){
-  // Simulate telemetry.
-  var temperature = 20 + (Math.random() * 15);
-  var humidity = 60 + (Math.random() * 20);
-
-  // Add the telemetry to the message body.
-  var data = JSON.stringify({ temperature: temperature, humidity: humidity });
-  var message = new Message(data);
-
-  // Add a custom application property to the message.
-  // An IoT hub can filter on these properties without access to the message body.
-  message.properties.add('temperatureAlert', (temperature > 30) ? 'true' : 'false');
-  console.log('Sending message: ' + message.getData());
-
-  // Send the message.
-  client.sendEvent(message, printResultFor('send'));
-}, 1000);


### PR DESCRIPTION
## Purpose
The sample did not use the client.open method, resulting in loosing the first message being sent.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
`node SimulatedDevice.js`

## What to Check
Original output (you can see the MessageEnqueued output is missing for the first message):
```
C:\dev\azure-iot-samples-node\iot-hub\Quickstarts\simulated-device>node SimulatedDevice.js
Sending message: {"temperature":24.413064626264358,"humidity":66.2882363906882}
Sending message: {"temperature":28.1767949014984,"humidity":78.21740772579443}
send status: MessageEnqueued
Sending message: {"temperature":31.272219111488816,"humidity":73.9826881094215}
send status: MessageEnqueued
Sending message: {"temperature":33.283799625390245,"humidity":66.79607833053939}
send status: MessageEnqueued
```

Updated output:
```
C:\dev\azure-iot-samples-node\iot-hub\Quickstarts\simulated-device>node SimulatedDevice.js
Connected to IoT Hub!
Sending message: {"temperature":30.764189085027333,"humidity":73.81771696300156}
send status: MessageEnqueued
Sending message: {"temperature":23.244885057255505,"humidity":77.90294085755515}
send status: MessageEnqueued
Sending message: {"temperature":32.66628442262574,"humidity":75.13879818231611}
send status: MessageEnqueued
Sending message: {"temperature":33.69924664313641,"humidity":76.17703623457663}
send status: MessageEnqueued
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->