### PR TITLE
Use config.json to actually configure GPIO LED Pin

### DIFF
--- a/iot-hub/Tutorials/RaspberryPiApp/config.json
+++ b/iot-hub/Tutorials/RaspberryPiApp/config.json
@@ -2,7 +2,7 @@
   "simulatedData": false,
   "interval": 2000,
   "deviceId": "Raspberry Pi Node",
-  "LEDPin": 5,
+  "LEDPinGPIO": 24,
   "messageMax": 256,
   "credentialPath": "~/.iot-hub",
   "temperatureAlert": 30,

--- a/iot-hub/Tutorials/RaspberryPiApp/index.js
+++ b/iot-hub/Tutorials/RaspberryPiApp/index.js
@@ -85,7 +85,7 @@ function receiveMessageCallback(msg) {
 }
 function blinkLED() {
   // Light up LED for 500 ms
-    const led = new gpio(18, 'out');
+    const led = new gpio(config.LEDPinGPIO, 'out');
     led.writeSync(1);
     setTimeout(function () {
         led.writeSync(0);


### PR DESCRIPTION
## Purpose
* **config.json** included a configuration value, `LEDPin` which was not being used. Renamed to `LEDPinGPIO` to convey that it had to be the GPIO pin value not necessarily the board pin number.
* **index.js** was opening the wrong GPIO pin for the blink LED operation according to the tutorial and was not even using the configuration value.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Follow [http://docs.microsoft.com/azure/iot-hub/iot-hub-raspberry-pi-kit-node-get-started](http://docs.microsoft.com/azure/iot-hub/iot-hub-raspberry-pi-kit-node-get-started)


* Test the code
* Follow [http://docs.microsoft.com/azure/iot-hub/iot-hub-raspberry-pi-kit-node-get-started](http://docs.microsoft.com/azure/iot-hub/iot-hub-raspberry-pi-kit-node-get-started)

## What to Check
Verify that the following are valid
* LED actually blinks as configured when a message is sent to the IoT Hub

## Other Information
<!-- Add any other helpful information that may be needed here. -->