### PR TITLE
Removing trailing slash in endpoint

### DIFF
--- a/iot-hub/Quickstarts/read-d2c-messages/ReadDeviceToCloudMessages.js
+++ b/iot-hub/Quickstarts/read-d2c-messages/ReadDeviceToCloudMessages.js
@@ -35,7 +35,7 @@ const iotHubSasKey = "{your service primary key}";
 
 // If you have access to the Event Hub-compatible connection string from the Azure portal, then
 // you can skip the Azure CLI commands above, and assign the connection string directly here.
-const connectionString = `Endpoint=${eventHubsCompatibleEndpoint}/;EntityPath=${eventHubsCompatiblePath};SharedAccessKeyName=service;SharedAccessKey=${iotHubSasKey}`;
+const connectionString = `Endpoint=${eventHubsCompatibleEndpoint};EntityPath=${eventHubsCompatiblePath};SharedAccessKeyName=service;SharedAccessKey=${iotHubSasKey}`;
 
 var printError = function (err) {
   console.log(err.message);


### PR DESCRIPTION
Removing trailing slash in endpoint. 

const connectionString = `**Endpoint=${eventHubsCompatibleEndpoint}/**;EntityPath=${eventHubsCompatiblePath};SharedAccessKeyName=service;SharedAccessKey=${iotHubSasKey}`;

Resolves: https://github.com/microsoftdocs/azure-docs/issues/59278

## Purpose
The endpoint printed with a trailing slash to the console which is pasted to the read-d2c-messages sample project doesn't work because it adds a trailing slashes again.

E.g:

The messaging entity 'sb://ihsuprod.......ce.servicebus.windows.net//ioth........56605/$management' could not be found. To know more visit https://aka.ms/sbResourceMgrExceptions.
So in the code should delete the trailing slash:

// If you have access to the Event Hub-compatible connection string from the Azure portal, then
// you can skip the Azure CLI commands above, and assign the connection string directly here.
const connectionString = `Endpoint=${eventHubsCompatibleEndpoint}/;EntityPath=${eventHubsCompatiblePath};SharedAccessKeyName=service;SharedAccessKey=${iotHubSasKey}`;

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->