### PR TITLE
don't blinkLED for simulated data

### DIFF
--- a/iot-hub/Tutorials/RaspberryPiApp/index.js
+++ b/iot-hub/Tutorials/RaspberryPiApp/index.js
@@ -41,7 +41,9 @@ function sendMessage() {
       if (err) {
         console.error('[Device] Failed to send message to Azure IoT Hub due to:\n\t' + err.message);
       } else {
-        blinkLED();
+        if (!config.simulatedData) {
+          blinkLED();
+        }        
         console.log('[Device] Message sent to Azure IoT Hub');
       }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Even in case of simulatedData being set to true, the code tried to blinkLED and that fails when trying simulated data testing in Raspberry Pi. Thus just checking the flag before blinkLED call. Tested this and works correctly now without the sensor attached to the Pi.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Set simulatedData flag in config.json to true and then run:
sudo node index.js 'YOUR IoT HUB DEVICE CONNECTION STRING'
```

## What to Check
Verify that the following are valid
* You won't get an error about:
![image](https://user-images.githubusercontent.com/10384000/100290331-f11b5200-2f2f-11eb-8a0f-6eaf3c74f86d.png)

## Other Information
<!-- Add any other helpful information that may be needed here. -->