### PR TITLE
Update dependancy for onoff to avoid issue #170 bug

### DIFF
--- a/iot-hub/Tutorials/RaspberryPiApp/package.json
+++ b/iot-hub/Tutorials/RaspberryPiApp/package.json
@@ -12,7 +12,7 @@
     "azure-iot-device-mqtt": "^1.9.3",
     "azure-iot-device-amqp": "^1.9.3",
     "bme280-sensor": "^0.1.6",
-    "onoff": "^5.0.1"
+    "onoff": "^6.0.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Purpose

The `onoff` module is used to blink the LED in the [RaspberryPiApp sample](https://github.com/Azure-Samples/azure-iot-samples-node/tree/master/iot-hub/Tutorials/RaspberryPiApp).

There was a bug introduced in `onoff` version < `6.0.0`. It was fixed against [issue 170 for version 6.0.0 and greater](https://github.com/fivdi/onoff/issues/170)

Updating [`package.json` dependency](https://github.com/Azure-Samples/azure-iot-samples-node/blob/master/iot-hub/Tutorials/RaspberryPiApp/package.json#L15) so anyone learning from the sample does not run into the bug.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

*  [Walk through the documentation tutorial](https://docs.microsoft.com/azure/iot-hub/iot-hub-raspberry-pi-kit-node-get-started)

Without this change you will experience the error mentioned in [issue 170](https://github.com/fivdi/onoff/issues/170).


## What to Check

Without this change you will experience the error mentioned in [issue 170](https://github.com/fivdi/onoff/issues/170).

## Other Information
N/A